### PR TITLE
Fix Octo merge_admin command to properly handle squash merging

### DIFF
--- a/config/nvim/.config/nvim/keybindings/octo.md
+++ b/config/nvim/.config/nvim/keybindings/octo.md
@@ -124,21 +124,21 @@ Without specifying `delete` or `nodelete`, the command uses your `default_delete
 
 ##### Admin Merge Commands (Custom)
 
-For repositories with branch protection, use admin privileges. Unlike the basic commands, these require a PR number since they use the GitHub CLI directly:
+For repositories with branch protection, use admin privileges. These commands use a custom implementation that properly handles squash merging:
 
 | Command | Description |
 |---------|-------------|
-| `:Octo pr merge_admin <PR>` | Admin merge with defaults |
-| `:Octo pr merge_admin <PR> squash` | Admin squash merge |
-| `:Octo pr merge_admin <PR> rebase` | Admin rebase merge |
-| `:Octo pr merge_admin <PR> commit` | Admin standard merge |
-| `:Octo pr merge_admin <PR> squash delete` | Admin squash merge and delete |
-| `:Octo pr merge_admin <PR> nodelete` | Admin merge and keep branch |
+| `:OctoPrMergeAdmin <PR>` | Admin merge with defaults |
+| `:OctoPrMergeAdmin <PR> squash` | Admin squash merge |
+| `:OctoPrMergeAdmin <PR> rebase` | Admin rebase merge |
+| `:OctoPrMergeAdmin <PR> commit` | Admin standard merge |
+| `:OctoPrMergeAdmin <PR> squash delete` | Admin squash merge and delete |
+| `:OctoPrMergeAdmin <PR> nodelete` | Admin merge and keep branch |
 
 Examples:
-- `:Octo pr merge_admin 42` - Merge PR #42 with admin privileges using defaults
-- `:Octo pr merge_admin 42 squash delete` - Squash merge PR #42 and delete branch
-- `:Octo pr merge_admin` - Will prompt for PR number if not provided
+- `:OctoPrMergeAdmin 42` - Merge PR #42 with admin privileges using defaults
+- `:OctoPrMergeAdmin 42 squash delete` - Squash merge PR #42 and delete branch
+- `:OctoPrMergeAdmin` - Will prompt for PR number if not provided
 
 ##### Configuration Defaults
 

--- a/config/nvim/.config/nvim/lua/plugins/octo.lua
+++ b/config/nvim/.config/nvim/lua/plugins/octo.lua
@@ -18,61 +18,6 @@ return {
     require("octo").setup({
       default_merge_method = "commit",  -- or "squash" or "rebase"
       default_delete_branch = false,     -- or true if you prefer
-      commands = {
-        pr = {
-          merge_admin = function(opts)
-            local args = vim.split(opts.args or "", " ")
-            local pr_number = args[1] or vim.fn.input("PR number: ")
-            
-            -- Debug: Print args
-            print("Debug - args:", vim.inspect(args))
-            -- Test dummy change for PR testing
-            
-            -- Get config defaults
-            local config = require("octo.config").values
-            local merge_method = config.default_merge_method
-            local delete_branch = config.default_delete_branch
-            
-            print("Debug - initial merge_method:", merge_method)
-            
-            -- Parse arguments to override defaults
-            for i, arg in ipairs(args) do
-              print("Debug - processing arg", i, ":", arg)
-              if i > 1 then  -- Skip PR number
-                if arg == "squash" or arg == "rebase" or arg == "commit" then
-                  merge_method = arg
-                  print("Debug - set merge_method to:", merge_method)
-                elseif arg == "delete" then
-                  delete_branch = true
-                elseif arg == "nodelete" then
-                  delete_branch = false
-                end
-              end
-            end
-            
-            -- Map merge methods to gh CLI flags
-            local merge_flag = ""
-            if merge_method == "squash" then
-              merge_flag = "--squash"
-            elseif merge_method == "rebase" then
-              merge_flag = "--rebase"
-            else
-              merge_flag = "--merge"
-            end
-            
-            local cmd = "!gh pr merge " .. pr_number .. " " .. merge_flag .. " --admin"
-            if delete_branch then
-              cmd = cmd .. " --delete-branch"
-            end
-            
-            print("Debug - final merge_method:", merge_method)
-            print("Debug - final merge_flag:", merge_flag)
-            print("Debug - executing command:", cmd)
-            
-            vim.cmd(cmd)
-          end,
-        },
-      },
       default_remote = {"upstream", "origin"},
       ssh_aliases = {},
       reaction_viewer_hint_icon = "",
@@ -240,6 +185,65 @@ return {
           toggle_viewed = { lhs = "<leader><space>", desc = "toggle viewer viewed state" },
         },
       },
+    })
+    
+    -- Create custom merge_admin command
+    vim.api.nvim_create_user_command("OctoPrMergeAdmin", function(opts)
+      local args = vim.split(opts.args or "", "%s+")
+      -- Filter out empty strings
+      args = vim.tbl_filter(function(arg) return arg ~= "" end, args)
+      
+      local pr_number = args[1] or vim.fn.input("PR number: ")
+      
+      -- Debug: Print args
+      print("Debug - args:", vim.inspect(args))
+      print("Debug - pr_number:", pr_number)
+      
+      -- Get config defaults
+      local config = require("octo.config").values
+      local merge_method = config.default_merge_method
+      local delete_branch = config.default_delete_branch
+      
+      print("Debug - initial merge_method:", merge_method)
+      
+      -- Parse arguments to override defaults
+      for i, arg in ipairs(args) do
+        print("Debug - processing arg", i, ":", arg)
+        if i > 1 then  -- Skip PR number
+          if arg == "squash" or arg == "rebase" or arg == "commit" then
+            merge_method = arg
+            print("Debug - set merge_method to:", merge_method)
+          elseif arg == "delete" then
+            delete_branch = true
+          elseif arg == "nodelete" then
+            delete_branch = false
+          end
+        end
+      end
+      
+      -- Map merge methods to gh CLI flags
+      local merge_flag = ""
+      if merge_method == "squash" then
+        merge_flag = "--squash"
+      elseif merge_method == "rebase" then
+        merge_flag = "--rebase"
+      else
+        merge_flag = "--merge"
+      end
+      
+      local cmd = "!gh pr merge " .. pr_number .. " " .. merge_flag .. " --admin"
+      if delete_branch then
+        cmd = cmd .. " --delete-branch"
+      end
+      
+      print("Debug - final merge_method:", merge_method)
+      print("Debug - final merge_flag:", merge_flag)
+      print("Debug - executing command:", cmd)
+      
+      vim.cmd(cmd)
+    end, {
+      nargs = "*",
+      desc = "Admin merge PR with optional merge method and branch deletion"
     })
   end,
 }

--- a/config/nvim/.config/nvim/lua/plugins/octo.lua
+++ b/config/nvim/.config/nvim/lua/plugins/octo.lua
@@ -195,24 +195,16 @@ return {
       
       local pr_number = args[1] or vim.fn.input("PR number: ")
       
-      -- Debug: Print args
-      print("Debug - args:", vim.inspect(args))
-      print("Debug - pr_number:", pr_number)
-      
       -- Get config defaults
       local config = require("octo.config").values
       local merge_method = config.default_merge_method
       local delete_branch = config.default_delete_branch
       
-      print("Debug - initial merge_method:", merge_method)
-      
       -- Parse arguments to override defaults
       for i, arg in ipairs(args) do
-        print("Debug - processing arg", i, ":", arg)
         if i > 1 then  -- Skip PR number
           if arg == "squash" or arg == "rebase" or arg == "commit" then
             merge_method = arg
-            print("Debug - set merge_method to:", merge_method)
           elseif arg == "delete" then
             delete_branch = true
           elseif arg == "nodelete" then
@@ -235,10 +227,6 @@ return {
       if delete_branch then
         cmd = cmd .. " --delete-branch"
       end
-      
-      print("Debug - final merge_method:", merge_method)
-      print("Debug - final merge_flag:", merge_flag)
-      print("Debug - executing command:", cmd)
       
       vim.cmd(cmd)
     end, {

--- a/config/nvim/.config/nvim/lua/plugins/octo.lua
+++ b/config/nvim/.config/nvim/lua/plugins/octo.lua
@@ -26,6 +26,7 @@ return {
             
             -- Debug: Print args
             print("Debug - args:", vim.inspect(args))
+            -- Test dummy change for PR testing
             
             -- Get config defaults
             local config = require("octo.config").values

--- a/config/nvim/.config/nvim/lua/plugins/octo.lua
+++ b/config/nvim/.config/nvim/lua/plugins/octo.lua
@@ -24,16 +24,23 @@ return {
             local args = vim.split(opts.args or "", " ")
             local pr_number = args[1] or vim.fn.input("PR number: ")
             
+            -- Debug: Print args
+            print("Debug - args:", vim.inspect(args))
+            
             -- Get config defaults
             local config = require("octo.config").values
             local merge_method = config.default_merge_method
             local delete_branch = config.default_delete_branch
             
+            print("Debug - initial merge_method:", merge_method)
+            
             -- Parse arguments to override defaults
             for i, arg in ipairs(args) do
+              print("Debug - processing arg", i, ":", arg)
               if i > 1 then  -- Skip PR number
                 if arg == "squash" or arg == "rebase" or arg == "commit" then
                   merge_method = arg
+                  print("Debug - set merge_method to:", merge_method)
                 elseif arg == "delete" then
                   delete_branch = true
                 elseif arg == "nodelete" then
@@ -56,6 +63,10 @@ return {
             if delete_branch then
               cmd = cmd .. " --delete-branch"
             end
+            
+            print("Debug - final merge_method:", merge_method)
+            print("Debug - final merge_flag:", merge_flag)
+            print("Debug - executing command:", cmd)
             
             vim.cmd(cmd)
           end,


### PR DESCRIPTION
## Summary
- Fixed broken `merge_admin` command that was incorrectly using `--merge` flag instead of `--squash` when `squash` argument was provided
- Replaced invalid Octo commands configuration with proper Neovim user command `:OctoPrMergeAdmin`
- Updated documentation to reflect new command syntax

## Changes
- **Fixed**: Squash merge functionality now correctly uses `--squash` flag instead of defaulting to `--merge`
- **Added**: `:OctoPrMergeAdmin` user command with proper argument parsing
- **Updated**: Documentation in `octo.md` with correct command examples
- **Removed**: Invalid `commands.pr.merge_admin` configuration that wasn't supported by Octo.nvim

## Usage
- `:OctoPrMergeAdmin <PR> squash` - Now correctly executes `gh pr merge <PR> --squash --admin`
- `:OctoPrMergeAdmin <PR> squash delete` - Squash merge and delete branch
- `:OctoPrMergeAdmin <PR>` - Use default merge method from config

## Test plan
- [x] Tested `:OctoPrMergeAdmin 6 squash` command 
- [x] Verified correct `--squash` flag is used instead of `--merge`
- [x] Confirmed argument parsing works correctly for all merge methods
- [x] Updated documentation reflects new command syntax

🤖 Generated with [Claude Code](https://claude.ai/code)