### PR TITLE
Add Neovim split keybindings; source zsh user env; add codex

### DIFF
--- a/config/nvim/.config/nvim/KEYBINDINGS.md
+++ b/config/nvim/.config/nvim/KEYBINDINGS.md
@@ -17,6 +17,8 @@ Basic editor commands and window navigation.
 |------|------|--------|
 | **Normal** | `<leader>w` | Save current buffer |
 | Normal | `<leader>y` | Yank to system clipboard |
+| Normal | `<leader>h` | Create horizontal split |
+| Normal | `<leader>v` | Create vertical split |
 | Normal | `<A-h>` | Focus split **left** |
 | Normal | `<A-j>` | Focus split **below** |
 | Normal | `<A-k>` | Focus split **above** |

--- a/config/nvim/.config/nvim/init.lua
+++ b/config/nvim/.config/nvim/init.lua
@@ -114,6 +114,9 @@ map("n", "<A-k>", "<C-w>k", { desc = "Move to window above" })
 map("n", "<A-l>", "<C-w>l", { desc = "Move to window on the right" })
 -- Toggle markdown rendering
 map("n", "<leader>m", "<cmd>RenderMarkdown toggle<cr>", { desc = "Toggle markdown rendering" })
+-- Split creation keybindings
+map("n", "<leader>h", "<cmd>split<cr>", { desc = "Split horizontal" })
+map("n", "<leader>v", "<cmd>vsplit<cr>", { desc = "Split vertical" })
 -- Clipboard yank keybindings
 map("v", "<leader>y", '"+y', { desc = "Yank to clipboard" })
 map("n", "<leader>y", '"+y', { desc = "Yank to clipboard" })

--- a/config/zsh/.zshenv
+++ b/config/zsh/.zshenv
@@ -17,3 +17,6 @@ export XDG_LIB_HOME="${HOME}/.local/lib"    # User libraries (shared libraries, 
 
 # Add essential directories to PATH
 export PATH="$XDG_BIN_HOME:$PATH"
+
+# Source user environment variables if the file exists
+[[ -f "$XDG_BIN_HOME/env" ]] && source "$XDG_BIN_HOME/env"

--- a/install/macos/Brewfile
+++ b/install/macos/Brewfile
@@ -26,6 +26,7 @@ brew "fnm"
 brew "libpq"
 brew "zsh-syntax-highlighting"
 brew "btop"
+brew "codex"
 
 # Applications (Casks)
 cask "ghostty"


### PR DESCRIPTION
Summary\n- Improve editor ergonomics with split-creation keybindings.\n- Make shell startup configurable per-machine by sourcing a user env file when present.\n- Ensure the codex tool is installed via Brewfile.\n\nChanges\n- Neovim\n  - Add split creation keybindings:\n    - <leader>h → :split\n    - <leader>v → :vsplit\n  - Document the new bindings in KEYBINDINGS.md\n- Zsh\n  - Source /env (typically ~/.local/bin/env) from .zshenv if the file exists\n- Brew\n  - Add brew "codex" to install list\n\nRationale\n- Faster window management in Neovim without reaching for commands.\n- Allow private/per-host exports without touching dotfiles by sourcing a local env file.\n- Keep development tooling (codex) managed via Brewfile for reproducibility.\n\nHow I tested\n- Neovim:\n  - Opened nvim and confirmed <leader>h and <leader>v create horizontal/vertical splits.\n- Zsh:\n  - Verified no error when ~/.local/bin/env does not exist.\n  - Created ~/.local/bin/env with export FOO=bar; opened a new shell; env var present.\n- Brew:\n  - Ran brew bundle check to confirm codex is recognized (or brew bundle install --no-upgrade to install).\n\nRisk/impact\n- Low:\n  - .zshenv change guarded by file-existence check.\n  - Keybindings are new leader mappings unlikely to conflict.\n- No breaking changes expected.\n\nChecklist\n- [x] Updates documented in KEYBINDINGS.md\n- [x] Tested locally\n- [x] No breaking changes\n- [ ] Optional: run brew bundle install to provision codex\n\nCommits included\n- e276c50 zsh: source user env file if present\n- 94a96f2 Add split creation keybindings to nvim config