### PR TITLE
macos: install Codex via npm; add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,8 @@
 - Commit messages: imperative mood with optional scope, e.g., `macos: install Codex via npm`. Follow with short bullets for details. Reference issues as `(#123)` when relevant.
 - Formatting: keep subject ≤72 chars; add a blank line before the body; wrap body at ~100 chars; use Markdown bullets (`-`) and fenced code blocks for commands.
 - Branch naming: short, hyphenated topic (e.g., `codex-npm`, `nvim-keybinds`).
-- Pull requests: clear description, rationale, example commands/output, and any breaking changes. Keep diffs focused; avoid unrelated refactors. Use simple Markdown headings: Summary, Changes, Testing, Notes.
+ - Pull requests: clear description, rationale, example commands/output, and any breaking changes. Keep diffs focused; avoid unrelated refactors. Use simple Markdown headings: Summary, Changes, Testing, Notes.
+ - GitHub CLI: use `--body-file` or `-F` with a Markdown file; avoid `-b` with `\n` since GitHub renders backslashes literally. Write the body via heredoc and pass the file to `gh pr create`.
 
 ## Security & Configuration Tips
 - Ensure `DOTFILES` points to the repo path before running setup.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `install/macos/`: macOS setup. Includes `Brewfile`, `setup.zsh`, and `tools/` for per-tool installers (e.g., `codex.zsh`, `opencode.zsh`, `claude-code.zsh`, `homebrew.zsh`, `fnm.zsh`).
+- `install/shell.sh`: Makes `zsh` the default shell (cross‑platform helpers).
+- `config/`: Stowable dotfile modules (zsh, nvim, tmux, ghostty, git, etc.).
+- `README.md` / `TODO.md`: Quick start and backlog.
+
+## Build, Test, and Development Commands
+- Setup macOS: `zsh install/macos/setup.zsh` (installs Homebrew, Brewfile packages, Node via `fnm`, and npm tools).
+- Homebrew only: `brew bundle --file=install/macos/Brewfile`.
+- Link dotfiles: `stow -nv */` (preview) then `stow -v */` (apply).
+- Install a single npm tool: `source install/macos/tools/codex.zsh && install_codex` (similar for `install_opencode`, `install_claude_code`).
+
+## Coding Style & Naming Conventions
+- Shell: prefer `zsh` for macOS tool scripts, `bash` for cross‑platform. Use `set -e` in installers, 4‑space indentation.
+- Functions: `install_<tool>()`, `setup_<area>()`; keep output concise and emoji‑friendly where used.
+- Filenames: lowercase with hyphens (e.g., `homebrew.zsh`, `codex.zsh`). One installer per file under `tools/`.
+- Keep `setup.zsh` phased (Xcode → Homebrew → Brewfile → Node → npm tools).
+
+## Testing Guidelines
+- No formal test suite. Validate by running commands and checking versions:
+  - `zsh install/macos/setup.zsh`
+  - `brew --version`, `stow --version`, `node -v`, `npm -v`
+  - `codex --version`, `opencode --version`, `claude-code --version`
+- Use `stow -nv */` before linking to avoid conflicts.
+
+## Commit & Pull Request Guidelines
+- Commit messages: imperative mood with optional scope, e.g., `macos: install Codex via npm`. Follow with short bullets for details. Reference issues as `(#123)` when relevant.
+- Formatting: keep subject ≤72 chars; add a blank line before the body; wrap body at ~100 chars; use Markdown bullets (`-`) and fenced code blocks for commands.
+- Branch naming: short, hyphenated topic (e.g., `codex-npm`, `nvim-keybinds`).
+- Pull requests: clear description, rationale, example commands/output, and any breaking changes. Keep diffs focused; avoid unrelated refactors. Use simple Markdown headings: Summary, Changes, Testing, Notes.
+
+## Security & Configuration Tips
+- Ensure `DOTFILES` points to the repo path before running setup.
+- Node is managed via `fnm`; run `eval "$(fnm env)"` in sessions that install npm tools.
+- Avoid duplicate installs (e.g., uninstall brew-installed tools if switching to npm).

--- a/install/macos/Brewfile
+++ b/install/macos/Brewfile
@@ -26,7 +26,6 @@ brew "fnm"
 brew "libpq"
 brew "zsh-syntax-highlighting"
 brew "btop"
-brew "codex"
 
 # Applications (Casks)
 cask "ghostty"

--- a/install/macos/setup.zsh
+++ b/install/macos/setup.zsh
@@ -28,6 +28,7 @@ main() {
     # Phase 5: Install npm-based tools
     if command -v npm &> /dev/null; then
         echo "📦 Installing npm-based tools..."
+        install_codex
         install_opencode
         install_claude_code
     fi

--- a/install/macos/tools/codex.zsh
+++ b/install/macos/tools/codex.zsh
@@ -1,0 +1,23 @@
+#!/usr/bin/env zsh
+# Codex CLI installation script (npm-based)
+
+install_codex() {
+    if command -v npm >/dev/null 2>&1; then
+        if ! command -v codex >/dev/null 2>&1; then
+            echo "Installing Codex CLI..."
+            npm install -g @openai/codex
+        else
+            echo "Codex CLI is already installed"
+        fi
+    else
+        echo "npm not available for Codex installation"
+        echo "Please install Node.js first (e.g., via fnm)"
+        return 1
+    fi
+}
+
+# Run if executed directly
+if [[ "${(%):-%x}" == "${0}" ]]; then
+    install_codex
+fi
+


### PR DESCRIPTION
## Summary
Switch Codex install from Homebrew to npm and add a concise contributor guide.

## Changes
- Remove brew "codex" from `install/macos/Brewfile`
- Add npm installer at `install/macos/tools/codex.zsh`
- Call `install_codex` from `install/macos/setup.zsh`
- Add `AGENTS.md` with project structure, commands, style, and PR guidance

## Testing
- Ran `zsh install/macos/setup.zsh`
- Verified npm tools install: `codex`, `opencode`, `claude-code`
- Confirmed `brew bundle --file=install/macos/Brewfile` runs without the codex entry

## Notes
- If Codex was installed via Homebrew: `brew uninstall codex`
- Branch: `codex-npm` → Base: `main`
