### PR TITLE
feat(macos,ghostty): migrate uv install; adjust Ghostty opacity

### DIFF
--- a/config/ghostty/.config/ghostty/config
+++ b/config/ghostty/.config/ghostty/config
@@ -8,3 +8,5 @@ font-family = JetBrainsMono NFM Regular
 keybind = shift+enter=text:\n
 keybind = cmd+s=new_split:left
 keybind = cmd+shift+s=new_split:up
+
+background-opacity = 1 

--- a/install/macos/Brewfile
+++ b/install/macos/Brewfile
@@ -5,7 +5,6 @@
 
 # CLI Tools
 brew "stow"
-brew "uv"
 brew "bat"
 brew "gum"
 brew "rich-cli"

--- a/install/macos/setup.zsh
+++ b/install/macos/setup.zsh
@@ -32,6 +32,10 @@ main() {
         install_opencode
         install_claude_code
     fi
+
+    # Phase 6: Install additional user-space tools
+    echo "🧰 Installing additional tools..."
+    install_uv
     
     echo "✅ macOS setup complete!"
     echo "🔄 Restarting shell..."

--- a/install/macos/tools/uv.zsh
+++ b/install/macos/tools/uv.zsh
@@ -1,0 +1,43 @@
+#!/usr/bin/env zsh
+# uv (Astral) installation script
+
+install_uv() {
+    local has_brew=false
+    local brew_has_uv=false
+
+    if command -v brew >/dev/null 2>&1; then
+        has_brew=true
+        if brew list --formula 2>/dev/null | grep -qx "uv"; then
+            brew_has_uv=true
+        fi
+    fi
+
+    if [[ "$brew_has_uv" == true ]]; then
+        echo "🔄 Found Homebrew 'uv'; uninstalling to migrate..."
+        brew uninstall uv || true
+    fi
+
+    # If uv exists and not via Homebrew, keep it
+    if command -v uv >/dev/null 2>&1 && [[ "$brew_has_uv" == false ]]; then
+        echo "uv already installed (non-Homebrew)"
+        return 0
+    fi
+
+    echo "Installing uv (Astral)..."
+    mkdir -p "${XDG_BIN_HOME:-$HOME/.local/bin}"
+    # Official installer
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+
+    if command -v uv >/dev/null 2>&1; then
+        echo "uv installed successfully"
+    else
+        echo "uv installation completed, but 'uv' not found in PATH"
+        echo "Ensure ${XDG_BIN_HOME:-$HOME/.local/bin} is in your PATH"
+        return 1
+    fi
+}
+
+# Run if executed directly
+if [[ "${(%):-%x}" == "${0}" ]]; then
+    install_uv
+fi


### PR DESCRIPTION
Summary:
- Add install_uv tool using official Astral installer (curl | sh)
- Wire into setup.zsh as Phase 6 (additional tools)
- Remove Homebrew-managed `uv` to avoid duplicate installs/conflicts
- Ghostty: set `background-opacity = 1` for a fully opaque default

Testing:
- Syntax: `zsh -n install/macos/setup.zsh` and `zsh -n install/macos/tools/uv.zsh`
- Brewfile: `brew bundle --file=install/macos/Brewfile --no-lock --verbose`
- Optional: run `zsh install/macos/setup.zsh` to verify `install_uv` phase

Refs:
- n/a
