### PR TITLE
feat(nvim): statuscol file-only, idle autoreload, tree watchers

### DIFF
--- a/config/nvim/.config/nvim/KEYBINDINGS.md
+++ b/config/nvim/.config/nvim/KEYBINDINGS.md
@@ -16,14 +16,12 @@ Basic editor commands and window navigation.
 | Mode | Keys | Action |
 |------|------|--------|
 | **Normal** | `<leader>w` | Save current buffer |
-| Normal | `<leader>y` | Yank to system clipboard |
 | Normal | `<leader>h` | Create horizontal split |
 | Normal | `<leader>v` | Create vertical split |
 | Normal | `<A-h>` | Focus split **left** |
 | Normal | `<A-j>` | Focus split **below** |
 | Normal | `<A-k>` | Focus split **above** |
 | Normal | `<A-l>` | Focus split **right** |
-| **Visual** | `<leader>y` | Yank selection to system clipboard |
 
 ---
 

--- a/config/nvim/.config/nvim/README.md
+++ b/config/nvim/.config/nvim/README.md
@@ -46,8 +46,7 @@ No additional steps are required because the config bootstraps
 * **render-markdown** for beautiful in-terminal markdown rendering with syntax highlighting
 * **bufferline** / **lualine** UI polish with transparent background
   when inside Ghostty
-* **Enhanced clipboard** with `<leader>y` for explicit system clipboard yanking
-* Sensible defaults: absolute line numbers, clipboard=unnamedplus,
+* Sensible defaults: absolute line numbers, clipboard=unnamed,unnamedplus,
   `updatetime=250`, etc.
 
 ---
@@ -112,5 +111,9 @@ lazy-lock.json          plugin lock-file (generated)
 ```
 
 ---
+
+## Health Check
+
+- Run `:checkhealth` to verify environment and providers.
 
 [folke/lazy.nvim]: https://github.com/folke/lazy.nvim

--- a/config/nvim/.config/nvim/lua/util/autoreload.lua
+++ b/config/nvim/.config/nvim/lua/util/autoreload.lua
@@ -1,21 +1,46 @@
 local M = {}
 
+-- Only run checktime for normal, modifiable file buffers
+local function maybe_checktime(buf)
+    local bt = vim.bo[buf].buftype
+    if bt == "" and vim.bo[buf].modifiable then
+        pcall(vim.cmd, "silent! checktime")
+    end
+end
+
 function M.setup()
     vim.opt.autoread = true
 
+    -- Focus/buffer switches: catch external changes when returning or swapping buffers
     local grp = vim.api.nvim_create_augroup("AutoReloadOnFocus", { clear = true })
     vim.api.nvim_create_autocmd({ "FocusGained", "TermLeave", "TermClose", "BufEnter", "BufWinEnter" }, {
         group = grp,
         pattern = "*",
         desc = "Auto-reload changed files on focus/buffer switch",
         callback = function(args)
-            local bt = vim.bo[args.buf].buftype
-            if bt == "" and vim.bo[args.buf].modifiable then
-                pcall(vim.cmd, "silent! checktime")
+            maybe_checktime(args.buf)
+        end,
+    })
+
+    -- Light idle checks: periodically verify on CursorHold/InsertHold with a small debounce
+    local idle_grp = vim.api.nvim_create_augroup("AutoReloadIdle", { clear = true })
+    local last = 0
+    local min_interval = 800 -- ms between checks while idle
+    local uv = vim.uv or vim.loop
+
+    vim.api.nvim_create_autocmd({ "CursorHold", "CursorHoldI" }, {
+        group = idle_grp,
+        pattern = "*",
+        desc = "Auto-reload on idle (debounced checktime)",
+        callback = function()
+            local now = uv.now()
+            if now - last < min_interval then
+                return
             end
+            last = now
+            maybe_checktime(0)
         end,
     })
 end
 
 return M
-

--- a/config/nvim/.config/nvim/lua/util/autoreload.lua
+++ b/config/nvim/.config/nvim/lua/util/autoreload.lua
@@ -1,0 +1,21 @@
+local M = {}
+
+function M.setup()
+    vim.opt.autoread = true
+
+    local grp = vim.api.nvim_create_augroup("AutoReloadOnFocus", { clear = true })
+    vim.api.nvim_create_autocmd({ "FocusGained", "TermLeave", "TermClose", "BufEnter", "BufWinEnter" }, {
+        group = grp,
+        pattern = "*",
+        desc = "Auto-reload changed files on focus/buffer switch",
+        callback = function(args)
+            local bt = vim.bo[args.buf].buftype
+            if bt == "" and vim.bo[args.buf].modifiable then
+                pcall(vim.cmd, "silent! checktime")
+            end
+        end,
+    })
+end
+
+return M
+

--- a/config/nvim/.config/nvim/lua/util/editor.lua
+++ b/config/nvim/.config/nvim/lua/util/editor.lua
@@ -1,0 +1,19 @@
+local M = {}
+
+function M.setup()
+    -- Numbers & gutter defaults
+    vim.opt.number         = true
+    vim.opt.relativenumber = true
+    vim.opt.signcolumn     = "auto:1"
+    vim.opt.numberwidth    = 5
+
+    -- Clipboard, timing, indent
+    -- Prefer system clipboard ('+'); fall back to X selection ('*') when '+''s provider is unavailable
+    vim.opt.clipboard  = "unnamed,unnamedplus"
+    vim.opt.updatetime = 250
+    vim.opt.shiftwidth = 4
+    vim.opt.tabstop    = 4
+    vim.opt.expandtab  = true
+end
+
+return M

--- a/config/nvim/.config/nvim/lua/util/gutter.lua
+++ b/config/nvim/.config/nvim/lua/util/gutter.lua
@@ -1,0 +1,23 @@
+local M = {}
+
+local function update_numberwidth()
+    local total  = vim.api.nvim_buf_line_count(0)
+    local digits = tostring(total):len()
+    local width  = math.max(2, math.min(4, digits))
+    vim.opt_local.numberwidth = width
+end
+
+function M.setup()
+    local grp = vim.api.nvim_create_augroup("DynamicNumberWidth", { clear = true })
+    vim.api.nvim_create_autocmd({ "BufEnter", "BufWinEnter", "BufReadPost", "BufWritePost", "VimResized" }, {
+        group = grp,
+        pattern = "*",
+        desc = "Adjust numberwidth per window based on line count",
+        callback = function()
+            pcall(update_numberwidth)
+        end,
+    })
+end
+
+return M
+

--- a/config/nvim/.config/nvim/lua/util/terminal.lua
+++ b/config/nvim/.config/nvim/lua/util/terminal.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+function M.setup()
+    -- General terminal/GUI defaults
+    vim.opt.termguicolors = true
+    vim.opt.background    = "dark"
+
+    -- Note: Transparent backgrounds are handled by Catppuccin in colorscheme.lua
+    -- Apply subtle diagnostic undercurls when running inside Ghostty
+    local in_ghostty = require("util.ghostty").active
+    if in_ghostty then
+        vim.api.nvim_set_hl(0, "DiagnosticUnderlineError", { undercurl = true, sp = "#ff5c5c" })
+        vim.api.nvim_set_hl(0, "DiagnosticUnderlineWarn",  { undercurl = true, sp = "#f0e130" })
+    end
+end
+
+return M
+


### PR DESCRIPTION
Summary:
- Modularize editor behavior into util modules (`util/editor.lua`, `util/autoreload.lua`, `util/gutter.lua`, `util/terminal.lua`).
- Enable built-in Lua module cache (`vim.loader.enable()`), guarded for older Neovim.
- Clipboard: use `clipboard=unnamed,unnamedplus` for cross-platform fallback; remove redundant `<leader>y` mapping and document `:checkhealth`.
- Autoreload: add light, debounced idle checks (`CursorHold`/`CursorHoldI`) to run `:checktime` alongside existing focus/buffer triggers.
- Status column: disable global assignment and apply only to real file buffers; keep explicit hides for tree/help/dashboard.
- NvimTree: enable filesystem watchers (200ms debounce) and add debounced `FocusGained` refresh when visible.

Changes:
- `init.lua`: call new util modules; remove `<leader>y` mapping.
- `lua/util/*`: new editor, autoreload, gutter, terminal helpers.
- `plugins/statuscol.lua`: `setopt=false`; add local-only statuscolumn autocmds; keep special-buffer hides.
- `plugins/nvimtree.lua`: enable `filesystem_watchers`; add focus refresh.
- Docs: README clipboard defaults + health check; KEYBINDINGS cleanup.

Why:
- More deterministic startup/perf; robust status column behavior that never leaks into UI panes (e.g., NvimTree/Octo/help).
- Better responsiveness to external changes (fs watchers + focus refresh + idle checktime).
- Cleaner clipboard UX with safe cross-platform fallback; simpler keybindings surface.

Testing:
- Verified `&clipboard` → `unnamed,unnamedplus`; `:checkhealth` clipboard ok.
- Confirmed statuscol blank in NvimTree/Octo; present in normal files; survives layout changes.
- External edits + `git checkout`: NvimTree updates via watchers/focus; file buffers autoreload silently after idle.
- `:verbose au` shows new autocmd groups; no errors on startup.

Notes:
- Diff windows still show numbers (real file buffers). If desired, we can also hide in any `&diff` window as a follow-up.
