### PR TITLE
[codex] nvim: show hidden and ignored files in snacks

### DIFF
--- a/config/nvim/.config/nvim/lua/plugins/snacks.lua
+++ b/config/nvim/.config/nvim/lua/plugins/snacks.lua
@@ -1,0 +1,19 @@
+return {
+  {
+    "folke/snacks.nvim",
+    opts = {
+      picker = {
+        sources = {
+          explorer = {
+            hidden = true,
+            ignored = true,
+          },
+          files = {
+            hidden = true,
+            ignored = true,
+          },
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- add a local `snacks.nvim` override for the LazyVim config
- show hidden and ignored files by default in both the explorer and file picker

## Why
LazyVim's default `snacks.nvim` explorer and file picker hide hidden and gitignored files unless overridden. This repo did not have a local override, so dotfiles and ignored files were missing from the default navigation flows.

## Testing
- loaded Neovim headlessly against the repo config with `XDG_CONFIG_HOME` pointed at `config/nvim/.config`
- verified the resolved `snacks` picker config sets `hidden = true` and `ignored = true` for both `explorer` and `files`
